### PR TITLE
Update for IntelliJ IDEA 2024.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.12
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222
-pluginUntilBuild = 232.*
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
Hello!

This PR is quite simple, in that it updates the `gradle.properties` file to support until the 2024.1.x branch series of IntelliJ IDEA so it can be built for it. No further changes were required to make it build.