### PR TITLE
Implement ElementColorProvider

### DIFF
--- a/src/main/java/org/c3lang/intellij/C3ElementColorProvider.kt
+++ b/src/main/java/org/c3lang/intellij/C3ElementColorProvider.kt
@@ -1,0 +1,24 @@
+package org.c3lang.intellij
+
+import com.intellij.openapi.editor.ElementColorProvider
+import com.intellij.psi.PsiElement
+import com.intellij.ui.JBColor
+import org.c3lang.intellij.psi.C3LiteralExpr
+import java.awt.Color
+
+class C3ElementColorProvider : ElementColorProvider
+{
+    override fun getColorFrom(element: PsiElement): Color?
+    {
+        if (element !is C3LiteralExpr) return null
+        if (!element.text.matches(Regex("0x([\\dA-Fa-f]{8}|[\\dA-Fa-f]{6})"))) return null
+
+        val rgb = element.text.substring(2).toLong(16)
+
+        return JBColor(rgb.toInt(), rgb.toInt())
+    }
+
+    override fun setColorTo(element: PsiElement, color: Color)
+    {
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -75,6 +75,8 @@
     <codeInsight.lineMarkerProvider language="C3"
                                     implementationClass="org.c3lang.intellij.C3LineMarkerProvider" />
 
+    <colorProvider implementation="org.c3lang.intellij.C3ElementColorProvider" />
+
     <!--<gotoDeclarationHandler implementation="org.c3lang.intellij.actions.C3GotoDeclarationHandler"/>-->
 
     <lang.findUsagesProvider language="C3" implementationClass="org.c3lang.intellij.findUsages.C3FindUsagesProvider"/>


### PR DESCRIPTION
- added C3ElementColorProvider to display colors represented by a hexadecimal integer

Example `rgb`
![](https://i.imgur.com/mfu6Xr5.png)

Example `argb`
![](https://i.imgur.com/N9jqaj1.png)