### PR TITLE
Hotfix for Doc comments

### DIFF
--- a/src/main/java/org/c3lang/intellij/annotation/DocComment.kt
+++ b/src/main/java/org/c3lang/intellij/annotation/DocComment.kt
@@ -131,6 +131,9 @@ private fun annotateParamTags(element: PsiComment, holder: AnnotationHolder)
             if (it.parameter.name != null)
             {
                 args.add(it.parameter.name!!)
+            } else
+            {
+                args.add(it.parameter.type?.text!!)
             }
         }
     } else if (macro != null)
@@ -139,6 +142,9 @@ private fun annotateParamTags(element: PsiComment, holder: AnnotationHolder)
             if (it.parameter.name != null)
             {
                 args.add(it.parameter.name!!)
+            } else
+            {
+                args.add(it.parameter.type?.text!!)
             }
         }
     }


### PR DESCRIPTION
- Fixed doc comment not detecting untyped parameters in functions and macros